### PR TITLE
Security: Add headers and .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env*

--- a/vercel.json
+++ b/vercel.json
@@ -25,12 +25,20 @@
           "value": "DENY"
         },
         {
-          "key": "X-XSS-Protection",
-          "value": "1; mode=block"
-        },
-        {
           "key": "Referrer-Policy",
           "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://va.vercel-scripts.com; font-src 'self';"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Add `Content-Security-Policy`, `Strict-Transport-Security`, and `Permissions-Policy` headers to `vercel.json`
- Remove deprecated `X-XSS-Protection` header (can introduce vulnerabilities)
- Add `.env*` pattern to `.gitignore` as preventive measure

## Test plan
- [ ] Deploy to Vercel preview, check response headers in DevTools Network tab
- [ ] Confirm no CSP violations in browser console
- [ ] Confirm Vercel Analytics still loads
- [ ] Create `.env` file locally, verify it's ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)