### PR TITLE
SEO technical improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,23 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="theme-color" content="#60a5fa" />
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <div style="padding: 2rem; font-family: sans-serif; color: #cbd5e1; background: #0f172a; min-height: 100vh;">
+        <h1>Moritz Nentwig</h1>
+        <p>Software Developer & Security Engineer</p>
+        <p>Based in Lindau, Germany. M.Sc. Computer Science (IT Security), CompTIA CySA+ certified.</p>
+        <p>
+          <a href="mailto:m.nentwig98@web.de" style="color: #60a5fa;">Email</a> |
+          <a href="https://github.com/Morn98" style="color: #60a5fa;">GitHub</a> |
+          <a href="https://linkedin.com/in/moritz-nentwig" style="color: #60a5fa;">LinkedIn</a>
+        </p>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,3 @@
 User-agent: *
 Allow: /
 Sitemap: https://www.mentlabs.de/sitemap.xml
-
-# Security
-User-agent: *
-Disallow: /api/
-Disallow: /admin/

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Moritz Nentwig - Software Developer & Security Engineer",
+  "short_name": "Moritz Nentwig",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#60a5fa",
+  "icons": [
+    { "src": "/favicon-32x32.png", "sizes": "32x32", "type": "image/png" },
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" }
+  ]
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,38 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.mentlabs.de/</loc>
-    <lastmod>2025-12-23</lastmod>
+    <lastmod>2026-02-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://www.mentlabs.de/#home</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.mentlabs.de/#skills</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://www.mentlabs.de/#experience</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.mentlabs.de/#projects</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://www.mentlabs.de/#contact</loc>
-    <lastmod>2025-12-23</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.6</priority>
   </url>
 </urlset>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -61,9 +61,9 @@ const Contact = () => {
           })}
         </div>
 
-        <div className="contact-footer">
+        <footer className="contact-footer">
           <p>Available for freelance opportunities and consulting</p>
-        </div>
+        </footer>
       </div>
     </section>
   );

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -7,6 +7,7 @@ const experiences = [
     company: 'LEAPTER GmbH',
     location: 'Germany',
     period: 'Starting January 2026',
+    startDate: '2026-01',
     type: 'professional',
     responsibilities: [
       'Position begins January 2026 - details to be updated'
@@ -17,6 +18,8 @@ const experiences = [
     company: 'Liechtensteinische Landesbank AG',
     location: 'Vaduz, Liechtenstein',
     period: 'Sep 2025 - Dec 2025',
+    startDate: '2025-09',
+    endDate: '2025-12',
     type: 'professional',
     responsibilities: [
       'Security architecture design and documentation',
@@ -30,6 +33,8 @@ const experiences = [
     company: 'Liechtensteinische Landesbank AG',
     location: 'Vaduz, Liechtenstein',
     period: 'Sep 2024 - Aug 2025',
+    startDate: '2024-09',
+    endDate: '2025-08',
     type: 'professional',
     responsibilities: [
       'Analysis, handling and remediation of security incidents',
@@ -47,6 +52,8 @@ const experiences = [
     company: 'ACTICO GmbH',
     location: 'Immenstaad am Bodensee, Germany',
     period: 'Oct 2023 - Apr 2024',
+    startDate: '2023-10',
+    endDate: '2024-04',
     type: 'professional',
     responsibilities: [
       'Creating a concept for a zero trust architecture in container-based microservice application'
@@ -57,6 +64,8 @@ const experiences = [
     company: 'ACTICO GmbH',
     location: 'Immenstaad am Bodensee, Germany',
     period: 'Jun 2022 - Sep 2023',
+    startDate: '2022-06',
+    endDate: '2023-09',
     type: 'professional',
     responsibilities: [
       'Independent implementation of features and bug fixes in Java and Angular',
@@ -71,6 +80,8 @@ const experiences = [
     company: 'MOGWAI Labs GmbH',
     location: 'Ulm, Germany',
     period: 'May 2021 - Oct 2021',
+    startDate: '2021-05',
+    endDate: '2021-10',
     type: 'professional',
     responsibilities: [
       'Vulnerability analysis of web applications',
@@ -86,6 +97,8 @@ const experiences = [
     company: 'University of Applied Sciences Weingarten',
     location: 'Weingarten, Germany',
     period: '2022 - 2024',
+    startDate: '2022',
+    endDate: '2024',
     type: 'education',
     responsibilities: [
       'Specialization in IT Security',
@@ -98,6 +111,8 @@ const experiences = [
     company: 'University of Applied Sciences Ulm',
     location: 'Ulm, Germany',
     period: '2018 - 2022',
+    startDate: '2018',
+    endDate: '2022',
     type: 'education',
     responsibilities: [
       'Focus on IT Security and Business Administration',
@@ -128,7 +143,13 @@ const Experience = () => {
               <div className="timeline-content">
                 <div className="timeline-header">
                   <h3 className="timeline-title">{exp.title}</h3>
-                  <span className="timeline-period">{exp.period}</span>
+                  <span className="timeline-period">
+                    {exp.endDate ? (
+                      <><time dateTime={exp.startDate}>{exp.period.split(' - ')[0]}</time> - <time dateTime={exp.endDate}>{exp.period.split(' - ')[1]}</time></>
+                    ) : (
+                      <>Starting <time dateTime={exp.startDate}>{exp.period.replace('Starting ', '')}</time></>
+                    )}
+                  </span>
                 </div>
                 <h4 className="timeline-company">
                   {exp.company}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -23,18 +23,26 @@ const Home = () => {
               <em>"I like to build, test, and break stuff - curiosity drives the process. 🧑‍💻📚"</em>
             </p>
             <div className="home-cta">
-              <button
+              <a
+                href="#skills"
                 className="cta-button primary"
-                onClick={() => scrollToSection('skills')}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection('skills');
+                }}
               >
                 View Skills
-              </button>
-              <button
+              </a>
+              <a
+                href="#contact"
                 className="cta-button secondary"
-                onClick={() => scrollToSection('contact')}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection('contact');
+                }}
               >
                 Get in Touch
-              </button>
+              </a>
             </div>
           </div>
         </div>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -76,15 +76,17 @@ const Navigation = () => {
         <ul className={`nav-menu ${isMobileMenuOpen ? 'active' : ''}`}>
           {navItems.map((item) => (
             <li key={item.id} className="nav-item">
-              <button
+              <a
+                href={`#${item.id}`}
                 className={`nav-link ${activeSection === item.id ? 'active' : ''}`}
-                onClick={() => {
+                onClick={(e) => {
+                  e.preventDefault();
                   scrollToSection(item.id);
                   setIsMobileMenuOpen(false);
                 }}
               >
                 {item.label}
-              </button>
+              </a>
             </li>
           ))}
         </ul>

--- a/vercel.json
+++ b/vercel.json
@@ -30,7 +30,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://va.vercel-scripts.com; font-src 'self';"
+          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; connect-src 'self' https://va.vercel-scripts.com; font-src 'self' https://fonts.gstatic.com;"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary
- Fix CSP to allow Google Fonts (`font-src`, `style-src` in `vercel.json`)
- Switch nav links and CTA buttons from `<button>` to `<a href="#section">` for crawlability and accessibility
- Remove hash-fragment URLs from sitemap (ignored by Google) and update `lastmod`
- Consolidate `robots.txt` — remove duplicate `User-agent` block and non-existent `/api/`, `/admin/` paths
- Add web app manifest (`site.webmanifest`) with theme-color meta tag
- Wrap Experience dates in `<time datetime>` elements for machine-readable dates
- Change contact footer `<div>` to semantic `<footer>` element
- Add `<noscript>` fallback so JS-disabled browsers/crawlers see content instead of a blank page

## Test plan
- [ ] `npm run build` succeeds
- [ ] Nav links smooth-scroll correctly; right-click → "Copy link address" shows `#section` URLs
- [ ] CTA buttons ("View Skills", "Get in Touch") still work
- [ ] DevTools: `<time>` elements present in Experience section
- [ ] DevTools: `<footer>` element in Contact section
- [ ] `/site.webmanifest` loads in browser
- [ ] Disable JS → noscript fallback visible
- [ ] After deploy: Inter font loads (Network tab → `fonts.gstatic.com` not blocked by CSP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)